### PR TITLE
Fix issue #8: typos and update docs; minor code tweaks

### DIFF
--- a/00 pygamece.tex
+++ b/00 pygamece.tex
@@ -122,9 +122,9 @@ pdfproducer={LuaLaTeX}
 
 \begin{document}
 
-  \title{Introduction to \\ Pygame-ce\\2D Game Programming}
+  \title{Introduction to Pygame-ce 2D Game Programming}
   \author{Ralf Adams}
-  \date{Version 1.2 (\today)}
+  \date{(\today)}
 %  \maketitle
   
 \begin{titlepage}
@@ -135,7 +135,7 @@ pdfproducer={LuaLaTeX}
 	{\Large 2D Game Programming\par}
 	\vfill
 	{\large Ralf Adams\par}
-	{\large Version 1.2 (\today)\par}
+	{\large Version 1.2.1 (\today)\par}
 \end{titlepage}
   
   

--- a/0101_TheBeginning.tex
+++ b/0101_TheBeginning.tex
@@ -22,7 +22,7 @@ When you start the application now, you will see a nicely designed window with a
 In order to use Pygame, the module \texttt{pygame} must be imported into the program (\zeiref{srcStart0001}). This makes the \glspl{constant}, \glspl{function}, \glspl{event}, and \glspl{class} of the \gls{namespace} available.
 
 
-Pygame is not just about calling functions or creating objects; a hole subsystems must be initialized explicitly. In this example, this is done using the static function
+Pygame is not just about calling functions or creating objects; a whole subsystems must be initialized explicitly. In this example, this is done using the static function
 \texttt{pygame.init()}. Pygame is now connected to parts of the \Gls{os} system, to deliver and receive required information and actions. In \zeiref{srcStart0003} the Pygame engine is started by calling \texttt{init()}\myindex{pyg}{\texttt{init()}|underline}\randnotiz{init()}. It ist also possible to start only parts of the engine e.g. the sound subsystem by \texttt{pygame.mixer.init()}\myindex{pyg}{\texttt{mixer}!\texttt{init()}}.
 
 For our games, we need a \emph{playfield}/a window in which everything takes place. The class \texttt{pygame.Window}\myindex{pyg}{\texttt{Window}}\randnotiz{Window}

--- a/0106_Keyboard.tex
+++ b/0106_Keyboard.tex
@@ -49,7 +49,7 @@ Let us now turn to the actual handling of keyboard input: Pressing a key can tri
 
 Let us start with the boss key. In \zeiref{srcTastatur0004}, the constant \texttt{K\_ESCAPE}\myindex{pyg}{\texttt{K\_ESCAPE}}\randnotiz{K\_ESCAPE} is used to check whether the pressed key is the \keys{\esc}. As with clicking the window’s close button, the flag of the main program loop is then simply set to \false. Try it out!
 
-After that, the four arrow keys are handled starting at \zeiref{srcTastatur0005}ff. Using \randnotiz{K\_LEFT K\_RIGHT K\_UP K\_DOWN}\texttt{K\_LEFT}, \texttt{K\_RIGHT}, \texttt{K\_UP}, and \texttt{K\_DOWN}\myindex{pyg}{\texttt{K\_LEFT}}\myindex{pyg}{\texttt{K\_RIGHT}}\myindex{pyg}{\texttt{K\_UP}}\myindex{pyg}{\texttt{K\_DOWN}}, the corresponding arrow key is checked and the appropriate message is sent to the defender.
+After that, the four arrow keys are handled starting at \zeiref{srcTastatur0005}\,ff. Using \randnotiz{K\_LEFT K\_RIGHT K\_UP K\_DOWN}\texttt{K\_LEFT}, \texttt{K\_RIGHT}, \texttt{K\_UP}, and \texttt{K\_DOWN}\myindex{pyg}{\texttt{K\_LEFT}}\myindex{pyg}{\texttt{K\_RIGHT}}\myindex{pyg}{\texttt{K\_UP}}\myindex{pyg}{\texttt{K\_DOWN}}, the corresponding arrow key is checked and the appropriate message is sent to the defender.
 
 If one of the arrow keys is released (\texttt{pygame.KEYUP}\myindex{pyg}{\texttt{KEYUP}} in \zeiref{srcTastatur0006}), the spaceship is stopped.
 

--- a/0107_Fonts.tex
+++ b/0107_Fonts.tex
@@ -57,7 +57,7 @@ How can such a class be used in practice? Here is a simple example. A greeting i
 
 \lstsource{SRC/00 Introduction/07 Fonts/textoutput01.py}{47}{91}{python}{Text output using fonts (3),  Main program}{srcFonts00c} 
 
-The greeting can be resized using \keys{{+}} and \keys{{-}} (\zeiref{srcTextoutputSimple05}ff.). The keys \keys{r}, \keys{g}, and \keys{b} are used to manipulate the corresponding color channel. An uppercase letter increases the value (for example in \zeiref{srcTextoutputSimple09}), while the lowercase letter decreases it (for example in \zeiref{srcTextoutputSimple10}).
+The greeting can be resized using \keys{{+}} and \keys{{-}} (\zeiref{srcTextoutputSimple05}\,ff.). The keys \keys{r}, \keys{g}, and \keys{b} are used to manipulate the corresponding color channel. An uppercase letter increases the value (for example in \zeiref{srcTextoutputSimple09}), while the lowercase letter decreases it (for example in \zeiref{srcTextoutputSimple10}).
 
 In \abbref[vref]{picFont01} you can see one possible visual result.
 

--- a/0110_Mouse.tex
+++ b/0110_Mouse.tex
@@ -110,7 +110,7 @@ ID 2: Side Window (Mouse Pressed: '3' at (224, 25))
 \subsubsection{Surprise: No Double Click}
 
 \begin{warningbox}
-	In Pygamee, there is no built-in event for a mouse double click. Unlike classic desktop GUI frameworks, pygame only reports individual mouse button presses.
+	In Pygame, there is no built-in event for a mouse double click. Unlike classic desktop GUI frameworks, pygame only reports individual mouse button presses.
 \end{warningbox}
 
 This means you cannot ask directly whether a double click happened. Instead, you have to detect it yourself.

--- a/0112_Events.tex
+++ b/0112_Events.tex
@@ -297,7 +297,7 @@ In event-heavy applications, it may be useful to restrict which events are allow
                               NEWPARTICLES])
 \end{lstlisting} 
 
-Use event filtering sparingly and only when necessary. Blocking too many events and accidentally preventing essential input from being processed.
+Use event filtering sparingly and only when necessary. Blocking too many events can accidentally preventing essential input from being processed.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsubsection{Event-Based Input vs. State-Based Input}

--- a/gloss.tex
+++ b/gloss.tex
@@ -10,7 +10,7 @@
 {
 	name={Pygame-ce},
 	text={Pygame-ce},
-	description={A free and open-source library written in Python for developing 2D~games and multimedia applications. Pygame-ce is based on the C library SDL and provides functions for graphics rendering, event handling, audio playback, and input control via keyboard, mouse, and game controllers. Pygame was originally created by Pete Shinners in the year~2000 and for many years was the standard framework for Python-based game development. However, since the original project did not receive updates	for a long period of time, a fork called Pygame Community Edition (pygame-ce) was created in 2020. This version is actively developed by a community in order to support modern Python versions, improved graphics features (for example, alpha blending and better transformations),	and higher performance}
+	description={A free and open-source library written in Python for developing 2D~games and multimedia applications. Pygame-ce is based on the C library SDL and provides functions for graphics rendering, event handling, audio playback, and input control via keyboard, mouse, and game controllers. Pygame was originally created by Pete Shinners in the year~2000 and for many years was the standard framework for Python-based game development. However, since the original project did not receive updates	for a long period of time, a fork called Pygame Community Edition (pygame-ce) was created in 2023. This version is actively developed by a community in order to support modern Python versions, improved graphics features (for example, alpha blending and better transformations),	and higher performance}
 }
 
 \newglossaryentry{constant}
@@ -667,6 +667,14 @@
 	description={Wayland is a modern display server protocol for Linux and other Unix-like systems. It defines how graphical applications (clients) communicate with the display server (the compositor) to draw windows, handle input devices like keyboard and mouse, and manage screen updates. Unlike the older X11 system, Wayland is designed to be simpler, more secure, and more efficient. Many tasks that were previously handled by a separate window manager are integrated directly into the compositor, reducing complexity and latency.	In practice, Wayland often results in smoother graphics, better support for modern hardware, and improved security, since applications cannot freely access or manipulate each other’s windows. Popular desktop environments such as GNOME and KDE increasingly use Wayland as their default display system}
 }
 \label{GRENZE}
+
+
+\newdualentry{sdl} % label
+{SDL}            % abbreviation
+{Simple Direct Media Layer}  % long form
+{SDL is a cross-platform multimedia library written in C. It provides low-level access to graphics, sound, input devices (keyboard, mouse, game controllers), and window management. 
+	SDL is widely used in game development and serves as the underlying technology for many frameworks and engines. In the context of Pygame-ce, SDL handles the communication with the operating system, while Pygame provides a more convenient Python interface on top of it.
+	In short: SDL does the heavy lifting in the background, and Pygame makes it easy to use from Python} % description
 % ------------------------------------------------------------------------------------
 
 
@@ -780,12 +788,6 @@
 }
 
 
-
-
-\newdualentry{sdl} % label
-{SDL}            % abbreviation
-{Simple Direct Media Layer}  % long form
-{Eine plattformunabhängige API für die Programmierung von Grafiken, Sounds und Eingabegräte} % description
 
 
 

--- a/src/00 Introduction/01 TheBeginning/v02/start.py
+++ b/src/00 Introduction/01 TheBeginning/v02/start.py
@@ -7,7 +7,7 @@ def main():
         title="My first Pygame program",            # via function parameter
         position=(10, 50))  
     screen = window.get_surface()
-    clock = pygame.time.Clock()                     # Clock objekt§\label{srcStart0101}§
+    clock = pygame.time.Clock()                     # Clock object§\label{srcStart0101}§
  
     running = True
     while running:

--- a/src/00 Introduction/04 Moving/invader05.py
+++ b/src/00 Introduction/04 Moving/invader05.py
@@ -14,7 +14,7 @@ def main():
 
     defender_image = pygame.image.load("images/defender01.png").convert_alpha()
     defender_image = pygame.transform.scale(defender_image, (30, 30))
-    defender_rect = defender_image.get_rect()           # Rect-Objekt§\label{srcInvader0501}§
+    defender_rect = defender_image.get_rect()           # Rect-object§\label{srcInvader0501}§
     defender_rect.centerx = cfg.WINDOW.centerx          # Not only using left§\label{srcInvader0502}§
     defender_rect.bottom = cfg.WINDOW.height - 5        # Not only using top§\label{srcInvader0503}§
 

--- a/src/00 Introduction/12 Events/event02/events.py
+++ b/src/00 Introduction/12 Events/event02/events.py
@@ -5,8 +5,13 @@ from typing import Any, Tuple
 import config as cfg
 import pygame
 from config import MyEvents
-from pygame.constants import (K_ESCAPE, KEYDOWN, MOUSEBUTTONDOWN, QUIT,
-                              WINDOWPOS_CENTERED)
+from pygame.constants import (
+    K_ESCAPE,
+    KEYDOWN,
+    MOUSEBUTTONDOWN,
+    QUIT,
+    WINDOWPOS_CENTERED,
+)
 
 
 class Button(pygame.sprite.Sprite):
@@ -145,7 +150,7 @@ class Game:
             elif event.type == MyEvents.OVERFLOW:
                 if event.index < cfg.NOFBOXES - 1:
                     self.all_boxes.sprites()[event.index + 1].update(counter="inc")
-            elif event.type == MyEvents.NEWPARTICLES:  # Periodisches Event §\label{srcEvent0202}§
+            elif event.type == MyEvents.NEWPARTICLES:  # Periodic Event §\label{srcEvent0202}§
                 self.generate_particles(cfg.NEWNOFPARTICLES)
 
     def update(self):


### PR DESCRIPTION
Bump book version to 1.2.1 and apply various documentation fixes: correct typos/wording and spacing in multiple TeX chapters (TheBeginning, Keyboard, Fonts, Mouse, Events), update glossary (change pygame-ce fork year to 2023 and add an SDL entry), and regenerate the PDF. Also make small code/comment adjustments in examples: normalize English wording in start.py and invader05.py comments, reformat imports in events.py and update an inline comment to "Periodic Event". These are non-functional editorial changes.